### PR TITLE
Fix option adding example for hooks

### DIFF
--- a/hooks.md
+++ b/hooks.md
@@ -35,9 +35,11 @@ I know that was a lot of info. For simplicity's sake, you will want to focus on 
 This depends on what you want to do. Let's talk through **some common scenarios** below and see where you might want to dig in with hooks. (In all cases, assume that the explanation ends with "and then you write custom code to accomplish this.")
 
 ### "I want to add a YAML option that will do something custom for my world."
-I'm not sure you need my help finding the place for this one. :) Either hook in Options.py works for this, and you'd put your option definition there too. I'd recommend using the `after_options_defined` hook in Options.py, though, so you have the option to both create your own options or customize Manual options.
+I'm not sure you need my help finding the place for this one. :) Open up the hooks file Options.py and look for the comment that says "add them here", then you'd put your option definition in there. In the `before_options_defined` hook method.
 
 The custom thing that happens when the option is accounted for, however, would just go wherever that functionality would go normally. As in, when it's not controlled by an option.
+
+(And if you're looking to customize existing options -- whether yours or Manual's -- use the `after_options_defined` hook.)
 
 ### "I want to change the quantity of an item or items dynamically, or split that item's classification between two classifications."
 Sounds like you want to change items in the item pool during generation, so you want World.py. The item pool is handled in the "create_items" step of generation. The likely hook you want is `before_create_items_filler` in World.py, so that you still let Manual properly add filler items at the end.

--- a/manual_pokemontcgages_fuzzy/hooks/Options.py
+++ b/manual_pokemontcgages_fuzzy/hooks/Options.py
@@ -53,19 +53,12 @@ class LatePowerPokemon(DefaultOnToggle):
 
 # This is called before any manual options are defined, in case you want to define your own with a clean slate or let Manual define over them
 def before_options_defined(options: dict) -> dict:
-    # You can add your custom options either here or below.
-    #   The only difference is when you define an option of the same name that Manual is defining.
-    #   If that happens, when you add options here, you're allowing the Manual option to overwrite yours.
-    return options
+    # If you're wanting to add custom options, add them here. 
+    # Versions of Manual from 2025 on will no longer support adding them elsewhere.
+    #
+    # And make sure to name them in a unique way. Example: Don't have a 'goal' option; have a 'goal_orbs' option or something instead.
+    # (Otherwise, Manual will overwrite your 'goal' option with its core 'goal' option.)
 
-
-# This is called after any manual options are defined, in case you want to see what options are defined or want to modify the defined options
-def after_options_defined(options: dict) -> dict:
-    # Same note as above (in before_options_defined)
-    #   except in this case, you'd be overwriting any same-name options that Manual defined.
-    # Generally, this is probably better, but it's much better to just not have options of generic names.
-    #   Name your options specific to your game.
-    #   Example: Don't have a 'goal' option. Have a 'goal_orbs' option or something.
 
     # You don't have to use dict.update().
     # You can add them individually like:
@@ -77,7 +70,14 @@ def after_options_defined(options: dict) -> dict:
         'late_power_pokemon': LatePowerPokemon
     })
 
-    # Also, we have some category options that are defined when we create our categories,
+    return options
+
+
+# This is called after any manual options are defined, in case you want to see what options are defined or want to modify the defined options
+def after_options_defined(options: dict) -> dict:
+    # If you want to *modify* existing options -- whether your own or Manual's -- do that here.
+
+    # We have some category options that are defined when we create our categories,
     #   but we want to hide those in the spoiler / YAML. So let's do that here.
     for option in options.keys():
         if 'pack_remove_' in option:

--- a/manual_pokemontcgages_fuzzy/hooks/README.md
+++ b/manual_pokemontcgages_fuzzy/hooks/README.md
@@ -28,8 +28,8 @@ _Reminder: These functions are not defined by Manual. You add these. (They also 
 - [hooks/World.py](World.py) -> `before_create_regions`
 
 ### Creating custom options
-_Could be done in `before` or `after` hook. There's no difference when you're adding options._
-- [hooks/Options.py](Options.py) -> `after_options_defined`
+_Only do this from the `before` hook. The `after` hook will no longer work for this._
+- [hooks/Options.py](Options.py) -> `before_options_defined`
 
 ### Hiding category options in the spoiler log / YAML template
 - [hooks/Options.py](Options.py) -> `after_options_defined`


### PR DESCRIPTION
This PR updates the option adding example to work properly with newer (2025-on) versions of Manual. Shoutout to Flit in our Discord for pointing out the discrepancy!